### PR TITLE
Update module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -37,11 +37,13 @@
         }
 	],
     "relationships": {
-        "requires": {
-            "id": "_CodeMirror",
-            "type": "module",
-            "manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/codemirror-lib/master/module.json"
-        }
+        "requires": [
+            {
+                "id": "_CodeMirror",
+                "type": "module",
+                "manifest": "https://raw.githubusercontent.com/League-of-Foundry-Developers/codemirror-lib/master/module.json"
+            }
+        ]
     },
     "languages": [
         {


### PR DESCRIPTION
The v11.306 update to Foundry caused the module not to load and gave this error message:
```
[error] Metadata validation failed for module "custom-css": pkgs is not iterable
```
I did some digging and it looks like the issue was that it expects the `relationships.requires` property in `module.json` to be an array of objects, not just a single object. This fixes the issue and allows the module to load again.